### PR TITLE
codet5 support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img align="center" src="data/st5.png" alt="simpleT5">
 
 <p align="center">
-<b>Quickly train T5/mT5/byT5 models in just 3 lines of code
+<b>Quickly train T5/mT5/byT5 and CodeT5 [NEW] models in just 3 lines of code
 </b>
 </p>
 <p align="center">

--- a/simplet5/simplet5.py
+++ b/simplet5/simplet5.py
@@ -4,6 +4,7 @@ import pandas as pd
 from tqdm.auto import tqdm
 from transformers import (
     AdamW,
+    RobertaTokenizer,
     T5ForConditionalGeneration,
     MT5ForConditionalGeneration,
     ByT5Tokenizer,
@@ -286,6 +287,11 @@ class SimpleT5:
             )
         elif model_type == "byt5":
             self.tokenizer = ByT5Tokenizer.from_pretrained(f"{model_name}")
+            self.model = T5ForConditionalGeneration.from_pretrained(
+                f"{model_name}", return_dict=True
+            )
+        elif model_type == "codet5":
+            self.tokenizer = RobertaTokenizer.from_pretrained(f"{model_name}")
             self.model = T5ForConditionalGeneration.from_pretrained(
                 f"{model_name}", return_dict=True
             )


### PR DESCRIPTION
Needed to use this package for my experiemnts,

Salesforce/codet5-base uses a roberta tokenizer hence this pull request.

users can now specify : `model.from_pretrained("codet5","Salesforce/codet5-base")`

If you want to read through codet5

Here are the links:
https://huggingface.co/Salesforce/codet5-base

Kind regards,
Mosh