### PR TITLE
Make requirements less strict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas
 sentencepiece
 torch>=1.7.0,!=1.8.0
-transformers==4.10.0
-pytorch-lightning==1.4.5
+transformers>=4.10.0,<4.11.0
+pytorch-lightning>=1.4.5,<1.5.0


### PR DESCRIPTION
There is a problem to install packages using Poetry because it requires exact versions of the packages. To solve this I propose to adjust versions in `requirements.txt`